### PR TITLE
Fixed podspec for Cocoapods 1.5.3

### DIFF
--- a/TesseractOCR/G8Constants.h
+++ b/TesseractOCR/G8Constants.h
@@ -79,22 +79,22 @@ typedef NS_ENUM(NSUInteger, G8PageSegmentationMode){
 };
 
 /**
- * When Tesseract/Cube is initialized we can choose to instantiate/load/run
- * only the Tesseract part, only the Cube part or both along with the combiner.
+ * When Tesseract/LSTM is initialized we can choose to instantiate/load/run
+ * only the Tesseract part, only the LSTM part or both along with the combiner.
  */
 typedef NS_ENUM(NSUInteger, G8OCREngineMode){
     /**
-     *  Run Tesseract only - fastest
+     *  Run Tesseract only - fastest (deprecated)
      */
-    G8OCREngineModeTesseractOnly,
+    G8OCREngineModeTesseractOnly __attribute__((deprecated)),
     /**
-     *  Run Cube only - better accuracy, but slower
+     *  Run LSTM only - better accuracy, but slower
      */
-    G8OCREngineModeCubeOnly,
+    G8OCREngineModeLSTMOnly,
     /**
-     *  Run both and combine results - best accuracy
+     *  Run both and combine results - best accuracy (deprecated)
      */
-    G8OCREngineModeTesseractCubeCombined,
+    G8OCREngineModeTesseractLSTMCombined __attribute__((deprecated)),
 //    G8OCREngineModeDefault,
 };
 

--- a/TesseractOCR/G8Tesseract.mm
+++ b/TesseractOCR/G8Tesseract.mm
@@ -110,7 +110,7 @@ namespace tesseract {
 
 - (instancetype)initWithLanguage:(NSString*)language
 {
-    return [self initWithLanguage:language configDictionary:nil configFileNames:nil cachesRelatedDataPath:nil engineMode:G8OCREngineModeTesseractOnly];
+    return [self initWithLanguage:language configDictionary:nil configFileNames:nil cachesRelatedDataPath:nil engineMode:G8OCREngineModeLSTMOnly];
 }
 
 - (instancetype)initWithLanguage:(NSString *)language engineMode:(G8OCREngineMode)engineMode

--- a/TesseractOCRiOS.podspec
+++ b/TesseractOCRiOS.podspec
@@ -15,16 +15,12 @@ Pod::Spec.new do |s|
 
   s.source                     = { git: 'https://github.com/gali8/Tesseract-OCR-iOS.git', tag: s.version.to_s }
 
-  s.platform                   = :ios, '10.0'
-
   s.ios.source_files           = 'TesseractOCR/*.{h,m,mm}', 'TesseractOCR/ios/include/**/*.h'
   s.ios.private_header_files   = 'TesseractOCR/ios/include/**/*.h'
   s.ios.frameworks             = 'UIKit', 'Foundation'
 
   s.ios.deployment_target      = '10.0'
   s.ios.vendored_library       = 'TesseractOCR/ios/lib/*.a'
-
-  s.platform                   = :macos, '10.13'
 
   s.macos.source_files         = 'TesseractOCR/*.{h,m,mm}', 'TesseractOCR/macos/include/**/*.h'
   s.macos.private_header_files = 'TesseractOCR/macos/include/**/*.h'


### PR DESCRIPTION
Without these changes, it wasn't possible for me to use the pod (couldn't install it because of the podspec) and it didn't use the tesseract-4-LSTM-traineddata by default.